### PR TITLE
Bugfix

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -152,7 +152,7 @@ func (stack *stack) next(node *endpoint) {
 
 func (stack *stack) back() {
 	stack.node = stack.node.prior
-	stack.current.times = 0
+	// stack.current.times = 0
 	stack.queue.PushFront(stack.current)
 	stack.args.Remove(stack.args.Back())
 	stack.current = stack.history.Remove(stack.history.Back()).(*keyword)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module webapi
+
+go 1.13

--- a/host.go
+++ b/host.go
@@ -192,6 +192,7 @@ func (host *Host) Register(basePath string, controller Controller, middlewares .
 				if err != nil {
 					return
 				}
+				path = filepath.ToSlash(path)
 				if _, existed := host.handlers[option]; !existed {
 					host.handlers[option] = &endpoint{}
 				}

--- a/middlewares/accesslogger.go
+++ b/middlewares/accesslogger.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-webapi/webapi"
+	"webapi"
 )
 
 type (

--- a/middlewares/recover.go
+++ b/middlewares/recover.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"runtime"
 
-	"github.com/go-webapi/webapi"
+	"webapi"
 )
 
 var (

--- a/middlewares/static.go
+++ b/middlewares/static.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/go-webapi/webapi"
+	"webapi"
 )
 
 type (


### PR DESCRIPTION
There are 2 issues had been investigated:
- The recursive might meet stack overflow in an accidental path that matched after a generic name resolve.
- Windows path is not compatible in the old version.

These 2 bugs has been fixed with:
- Remove counter reset in back() method.
- Add ToSlash() method to final url generation and registration.